### PR TITLE
feat(watcher): skip drops_only streamers when all campaigns completed

### DIFF
--- a/configs/example.yaml.example
+++ b/configs/example.yaml.example
@@ -49,6 +49,7 @@ streamer_defaults:
   claim_moments: true
   watch_streak: true
   community_goals: false
+  drops_only: false # skip streamer when all active drop campaigns are completed
   chat: "ONLINE" # ALWAYS | NEVER | ONLINE | OFFLINE
   bet:
     strategy: "SMART" # MOST_VOTED | HIGH_ODDS | PERCENTAGE | SMART_MONEY | SMART | NUMBER_1..8

--- a/internal/config/account.go
+++ b/internal/config/account.go
@@ -86,6 +86,7 @@ type StreamerSettingsConfig struct {
 	ClaimMoments    *bool              `yaml:"claim_moments,omitempty"`
 	WatchStreak     *bool              `yaml:"watch_streak,omitempty"`
 	CommunityGoals  *bool              `yaml:"community_goals,omitempty"`
+	DropsOnly       *bool              `yaml:"drops_only,omitempty"`
 	Chat            string             `yaml:"chat,omitempty"`
 	Bet             *BetSettingsConfig `yaml:"bet,omitempty"`
 }
@@ -268,6 +269,9 @@ func (ssc *StreamerSettingsConfig) ToStreamerSettings(defaults *model.StreamerSe
 	}
 	if ssc.CommunityGoals != nil {
 		settings.CommunityGoalsEnabled = *ssc.CommunityGoals
+	}
+	if ssc.DropsOnly != nil {
+		settings.DropsOnly = *ssc.DropsOnly
 	}
 	if ssc.Chat != "" {
 		settings.Chat = model.ParseChatPresence(ssc.Chat)

--- a/internal/model/streamer.go
+++ b/internal/model/streamer.go
@@ -238,6 +238,7 @@ type StreamerSettings struct {
 	ClaimMoments          bool         `json:"claim_moments" yaml:"claim_moments"`
 	WatchStreak           bool         `json:"watch_streak" yaml:"watch_streak"`
 	CommunityGoalsEnabled bool         `json:"community_goals" yaml:"community_goals"`
+	DropsOnly             bool         `json:"drops_only" yaml:"drops_only"`
 	Bet                   *BetSettings `json:"bet,omitempty" yaml:"bet"`
 	Chat                  ChatPresence `json:"chat" yaml:"chat"`
 }

--- a/internal/twitch/minute_watched.go
+++ b/internal/twitch/minute_watched.go
@@ -270,11 +270,16 @@ func SelectStreamersToWatch(streamers []*model.Streamer, priorities []model.Prio
 	var onlineIndices []int
 	for i, s := range streamers {
 		s.Mu.RLock()
-		isOnline := s.IsOnline
-		onlineAt := s.OnlineAt
+		isOnline     := s.IsOnline
+		onlineAt     := s.OnlineAt
+		dropsOnly    := s.Settings != nil && s.Settings.DropsOnly
+		hasCampaigns := len(s.Stream.Campaigns) > 0
 		s.Mu.RUnlock()
 
 		if isOnline && (onlineAt.IsZero() || now.Sub(onlineAt) > 30*time.Second) {
+			if dropsOnly && !hasCampaigns {
+				continue
+			}
 			onlineIndices = append(onlineIndices, i)
 		}
 	}

--- a/internal/twitch/minute_watched_test.go
+++ b/internal/twitch/minute_watched_test.go
@@ -15,6 +15,11 @@ func makeOnlineStreamer(username string) *model.Streamer {
 	return s
 }
 
+func withCampaigns(s *model.Streamer) *model.Streamer {
+	s.Stream.Campaigns = []model.Campaign{{ID: "c1"}}
+	return s
+}
+
 func TestSelectStreamersToWatchPreservesPriorityOrder(t *testing.T) {
 	t.Parallel()
 
@@ -33,6 +38,42 @@ func TestSelectStreamersToWatchPreservesPriorityOrder(t *testing.T) {
 	}
 	if selected[0].Username != "first" || selected[1].Username != "second" {
 		t.Fatalf("expected stable order [first second], got [%s %s]", selected[0].Username, selected[1].Username)
+	}
+}
+
+func TestSelectStreamersToWatch_DropsOnly_SkippedWhenNoCampaigns(t *testing.T) {
+	t.Parallel()
+
+	done := makeOnlineStreamer("done")
+	done.Settings.DropsOnly = true
+
+	other := makeOnlineStreamer("other")
+
+	selected := SelectStreamersToWatch(
+		[]*model.Streamer{done, other},
+		[]model.Priority{model.PriorityOrder},
+		2,
+	)
+
+	if len(selected) != 1 || selected[0].Username != "other" {
+		t.Fatalf("expected only 'other', got %v", selected)
+	}
+}
+
+func TestSelectStreamersToWatch_DropsOnly_IncludedWhenHasCampaigns(t *testing.T) {
+	t.Parallel()
+
+	active := withCampaigns(makeOnlineStreamer("active"))
+	active.Settings.DropsOnly = true
+
+	selected := SelectStreamersToWatch(
+		[]*model.Streamer{active},
+		[]model.Priority{model.PriorityOrder},
+		1,
+	)
+
+	if len(selected) != 1 {
+		t.Fatalf("expected 1 selected streamer, got %d", len(selected))
 	}
 }
 

--- a/internal/watcher/category.go
+++ b/internal/watcher/category.go
@@ -280,6 +280,7 @@ func (cw *CategoryWatcher) evaluate(
 			defaults.Bet = &betCopy
 		}
 		defaults.FollowRaid = false
+		defaults.DropsOnly = dropsOnly
 		streamer.Settings = &defaults
 
 		cw.mu.Lock()


### PR DESCRIPTION
## Summary

- Adds `drops_only` setting to `StreamerSettings` (and the YAML config layer `StreamerSettingsConfig`)
- When `drops_only: true` and `Stream.Campaigns` is empty (all drops collected), the streamer is excluded from the minute-watched selection entirely — regardless of priority
- `CategoryWatcher` automatically propagates the per-category/global `drops_only` flag to newly discovered streamers
- Filtering happens at the `onlineIndices` build step in `SelectStreamersToWatch`, so the skip applies to all priority passes (ORDER, DROPS, STREAK) uniformly

## Test plan

- [ ] `go test ./internal/twitch/... -v -run TestSelectStreamersToWatch` — 4 tests pass (2 existing + 2 new)
- [ ] `go test ./...` — no regressions
- [ ] Manual: set `drops_only: true` on a streamer or category, verify miner stops watching after campaigns are cleared by `SyncCampaigns` (runs every 10 min)
- [ ] Manual: verify streamer resumes being watched when a new campaign starts (within next 10-min sync cycle)